### PR TITLE
Fix changelog msg

### DIFF
--- a/scripts/deepin_changelog.py
+++ b/scripts/deepin_changelog.py
@@ -710,6 +710,10 @@ def main(argv):
         # commits).
         if not commits:
             gbp.log.info("No changes detected from %s to %s." % (since, until))
+            cp.add_section(distribution="UNRELEASED", msg=[f"Update version to {version_change['version']}(No code changes!)"],
+                version=version_change,
+                dch_options=dch_options)
+            add_section = False
 
         if add_section:
             # If we end up here, then there were no commits to include,

--- a/scripts/deepin_changelog.py
+++ b/scripts/deepin_changelog.py
@@ -314,8 +314,7 @@ def do_release(changelog, repo, cp, use_git_author, dch_options):
     if snapshot:
         cp['MangledVersion'] = release
         mangle_changelog(changelog, cp)
-    cp.spawn_dch(release=True, author="Deepin Packages Builder", email="packages@deepin.org", dch_options=dch_options)
-
+    cp.spawn_dch(release=True, dch_options=dch_options)
 
 def do_snapshot(changelog, repo, next_snapshot):
     """
@@ -685,13 +684,13 @@ def main(argv):
                     # add an empty section with dch)
                     cp.add_section(distribution="UNRELEASED", msg=commit_msg,
                                 version=version_change,
-                                author="Deepin Packages Builder",
-                                email="packages@deepin.org",
+                                # author="Deepin Packages Builder",
+                                # email="packages@deepin.org",
                                 dch_options=dch_options)
                     # Adding a section only needs to happen once.
                     add_section = False
                 else:
-                    cp.add_entry(commit_msg, author="Deepin Packages Builder", email="packages@deepin.org", dch_options=dch_options)
+                    cp.add_entry(commit_msg, dch_options=dch_options)
 
         # Show thanks list
         if options.thanks_print or options.new_version:


### PR DESCRIPTION
1. changelog中的author和email字段支持通过DEBFULLNAME和DEBEMAIL环境变量设置
2. 修改在没有代码更改的情况下changelog信息，例如：
```
     deepin-gbp-dch-plugins (0.0.3) unstable; urgency=medium

          * Update version to 0.0.3(No code changes!)

     -- hudeng <hudeng@deepin.org>  Wed, 06 Dec 2023 11:53:55 +0800
```